### PR TITLE
Align Chat Bubbles Right and Left

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,8 @@
                 padding: 10px;
                 margin: 20px;
                 border-radius: 10px;
+                float: left;
+                width: calc(100% / 12 * 8);
             }
 
             /* Style for odd-indexed messages */
@@ -20,6 +22,8 @@
                 padding: 10px;
                 margin: 20px;
                 border-radius: 10px;
+                float: right;
+                width: calc(100% / 12 * 8);
             }
 
             button#reset-button {
@@ -34,7 +38,7 @@
         {% if history %}
         <!-- Chat history -->
         <div id="history" class="card">
-            <div class="card-content">
+            <div class="card-content" style="overflow: auto">
                 {% for message in history[1:] %} 
                     <div class="card {% if loop.index % 2 == 0 %}even{% else %}odd{% endif %}">
                         <p>{{ message }}</p>


### PR DESCRIPTION
I used ChatGPT to make these changes. First it changed the style of .odd and .even correctly, however now the chat bubbles did not stay properly in the wrapper div.

So I also sent ChatGPT that portion of the HTML and it added the inline style for overflow auto.

Up to you if you want to request the change and get it put in the styles, instead of inline. I know you're trying to keep this created by ChatGPT and this was what it did the first two questions. I can probably ask it to make that change so it is no longer inline.